### PR TITLE
🐛 Fixed email hash displayed during login

### DIFF
--- a/src/api/authentication/register.ts
+++ b/src/api/authentication/register.ts
@@ -58,7 +58,7 @@ const registerPostRequestSchema = Joi.object({
       rpName: config.rp.name,
       rpID: config.rp.id,
       userID: userDoc._id,
-      userName: userDoc.email.toString(),
+      userName: attestationGetRequest.value.email,
       timeout: 60000,
       attestationType: 'indirect',
       authenticatorSelection: {


### PR DESCRIPTION
During the WebAuthn process, Windows displays the username which was originally the hashed email. This pr fixes this bug and Windows now displays the original email instead. 